### PR TITLE
 possibility to set urlencode to false

### DIFF
--- a/HttpClientTrait.php
+++ b/HttpClientTrait.php
@@ -491,13 +491,28 @@ trait HttpClientTrait
             }
         }
 
+        $queryNotUrldecode = [];
+        foreach($queryArray as $k=>$v){
+            if(is_array($v) && isset($v['value'])){
+                if(isset($v['urldecode']) && $v['urldecode']===false){
+                    $queryNotUrldecode[$k] = $v['value'];
+                    unset($queryArray[$k]);
+                }
+            }
+        }
+
         $queryString = http_build_query($queryArray, '', '&', PHP_QUERY_RFC3986);
+
         $queryArray = [];
 
         if ($queryString) {
             foreach (explode('&', $queryString) as $v) {
                 $queryArray[rawurldecode(explode('=', $v, 2)[0])] = $v;
             }
+        }
+
+        foreach ($queryNotUrldecode as $k=>$v) {
+            $queryArray[$k] = $k.'='.$v;
         }
 
         return implode('&', $replace ? array_replace($query, $queryArray) : ($query + $queryArray));

--- a/Tests/HttpClientTraitTest.php
+++ b/Tests/HttpClientTraitTest.php
@@ -43,6 +43,7 @@ class HttpClientTraitTest extends TestCase
         yield ['http://example.com/?a=2&b=b', '.?a=2'];
         yield ['http://example.com/?a=3&b=b', '.', ['a' => 3]];
         yield ['http://example.com/?a=3&b=b', '.?a=0', ['a' => 3]];
+        yield ['http://example.com/?a=3&c=test_1,test_2&b=b', '.?a=3', ['c' => ['value'=>'test_1,test_2', 'urldecode'=>false]]];
     }
 
     /**


### PR DESCRIPTION
The feature offers a choice on encoding query

Q | A
-- | --
Branch? | master
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets |  
License | MIT
Doc PR |  

example:
```php
$httpClient = HttpClient::create();

$response = $httpClient->request('GET', 'http://example.com', [
    'query'=>[
        'key_1'=>['value'=>'example1,example2', 'urldecode'=>false],
        'key_2'=>'normal'
    ]
]);
```