### PR TITLE
Solving the bug with looping the removeDotSegments method in HttpClientTrait

### DIFF
--- a/HttpClientTrait.php
+++ b/HttpClientTrait.php
@@ -492,33 +492,96 @@ trait HttpClientTrait
             'fragment' => isset($parts['fragment']) ? '#'.$parts['fragment'] : null,
         ];
     }
-
+    
     /**
      * Removes dot-segments from a path.
      *
      * @see https://tools.ietf.org/html/rfc3986#section-5.2.4
+     * @param string $path
+     * @return string
      */
-    private static function removeDotSegments(string $path)
+    private static function removeDotSegments(string $path): string
     {
-        $result = '';
-
-        while (!\in_array($path, ['', '.', '..'], true)) {
-            if ('.' === $path[0] && (0 === strpos($path, $p = '../') || 0 === strpos($path, $p = './'))) {
-                $path = substr($path, \strlen($p));
-            } elseif ('/.' === $path || 0 === strpos($path, '/./')) {
-                $path = substr_replace($path, '/', 0, 3);
-            } elseif ('/..' === $path || 0 === strpos($path, '/../')) {
-                $i = strrpos($result, '/');
-                $result = $i ? substr($result, 0, $i) : '';
-                $path = substr_replace($path, '/', 0, 4);
-            } else {
-                $i = strpos($path, '/', 1) ?: \strlen($path);
-                $result .= substr($path, 0, $i);
-                $path = substr($path, $i);
-            }
+        if (strpos($path, '.') === false) {
+            return $path;
         }
-
-        return $result;
+        
+        $inputBuffer = $path;
+        $outputStack = [];
+        
+        /**
+         * 2.  While the input buffer is not empty, loop as follows:
+         */
+        while ($inputBuffer !== '') {
+            /**
+             * A.  If the input buffer begins with a prefix of "../" or "./",
+             *     then remove that prefix from the input buffer; otherwise,
+             */
+            if (strpos($inputBuffer, './') === 0) {
+                $inputBuffer = substr($inputBuffer, 2);
+                continue;
+            }
+            if (strpos($inputBuffer, '../') === 0) {
+                $inputBuffer = substr($inputBuffer, 3);
+                continue;
+            }
+            
+            /**
+             * B.  if the input buffer begins with a prefix of "/./" or "/.",
+             *     where "." is a complete path segment, then replace that
+             *     prefix with "/" in the input buffer; otherwise,
+             */
+            if ($inputBuffer === '/.') {
+                $outputStack[] = '/';
+                break;
+            }
+            if (strpos($inputBuffer, '/./') === 0) {
+                $inputBuffer = substr($inputBuffer, 2);
+                continue;
+            }
+            
+            /**
+             * C.  if the input buffer begins with a prefix of "/../" or "/..",
+             *     where ".." is a complete path segment, then replace that
+             *     prefix with "/" in the input buffer and remove the last
+             *     segment and its preceding "/" (if any) from the output
+             *     buffer; otherwise,
+             */
+            if ($inputBuffer === '/..') {
+                array_pop($outputStack);
+                $outputStack[] = '/';
+                break;
+            }
+            if (strpos($inputBuffer, '/../') === 0) {
+                array_pop($outputStack);
+                $inputBuffer = substr($inputBuffer, 3);
+                continue;
+            }
+            
+            /**
+             * D.  if the input buffer consists only of "." or "..", then remove
+             *     that from the input buffer; otherwise,
+             */
+            if ($inputBuffer === '.' || $inputBuffer === '..') {
+                break;
+            }
+            
+            /**
+             * E.  move the first path segment in the input buffer to the end of
+             *     the output buffer, including the initial "/" character (if
+             *     any) and any subsequent characters up to, but not including,
+             *     the next "/" character or the end of the input buffer.
+             */
+            if (($slashPos = strpos($inputBuffer, '/', 1)) === false) {
+                $outputStack[] = $inputBuffer;
+                break;
+            }
+            
+            $outputStack[] = substr($inputBuffer, 0, $slashPos);
+            $inputBuffer   = substr($inputBuffer, $slashPos);
+        }
+        
+        return implode($outputStack);
     }
 
     /**

--- a/Tests/HttpClientTraitTest.php
+++ b/Tests/HttpClientTraitTest.php
@@ -167,6 +167,10 @@ class HttpClientTraitTest extends TestCase
         yield ['/a//b/', '/a///../b/.'];
         yield ['/a/', '/a/b/..'];
         yield ['/a///b', '/a///b'];
+        yield ['/a/b', '/a/b'];
+        yield ['a/b', 'a/b'];
+        yield ['a/b/', 'a/b/'];
+        yield ['/a/b/', '/a/b/'];
     }
 
     public function testAuthBearerOption()


### PR DESCRIPTION
Testing options:
'/a/b',
 'a/b',
'a/b/',
'/a/b/',


When updating packages in one of my project, a bug was caught where sentry/sdk v 2.2.0 in the new version uses this package, for this reason, the start of checking the work of the sentry, the completion occurred with a memory overflow.