### PR TITLE
TraceableHttpClient: increase decorator's priority

### DIFF
--- a/DependencyInjection/HttpClientPass.php
+++ b/DependencyInjection/HttpClientPass.php
@@ -38,7 +38,7 @@ final class HttpClientPass implements CompilerPassInterface
             $container->register('.debug.'.$id, TraceableHttpClient::class)
                 ->setArguments([new Reference('.debug.'.$id.'.inner')])
                 ->addTag('kernel.reset', ['method' => 'reset'])
-                ->setDecoratedService($id);
+                ->setDecoratedService($id, null, 100);
             $container->getDefinition('data_collector.http_client')
                 ->addMethodCall('registerClient', [$id, new Reference('.debug.'.$id)]);
         }


### PR DESCRIPTION
Hello,

When I decorate my http client, all requests are not collected (and visible in the profiler) because of the decorator's priority of TraceableHttpClient. I think it should be in increased. I fixed an arbitrary value of 100.

What do you think about that ?

Ty